### PR TITLE
InventoryStakingV3: allow withdrawal to NFTs

### DIFF
--- a/src/interfaces/INFTXInventoryStakingV3.sol
+++ b/src/interfaces/INFTXInventoryStakingV3.sol
@@ -109,6 +109,8 @@ interface INFTXInventoryStakingV3 is IERC721Upgradeable {
     error Timelocked();
     error VaultIdMismatch();
     error ParentChildSame();
+    error RedeemNotAllowedWithoutTimelock();
+    error InsufficientVTokens();
 
     // =============================================================
     //                           INIT
@@ -138,7 +140,12 @@ interface INFTXInventoryStakingV3 is IERC721Upgradeable {
         address recipient
     ) external returns (uint256 positionId);
 
-    function withdraw(uint256 positionId, uint256 vTokenShares) external;
+    /// @notice This contract must be on the feeExclusion list to avoid redeem fees, else revert
+    function withdraw(
+        uint256 positionId,
+        uint256 vTokenShares,
+        uint256[] calldata nftIds
+    ) external;
 
     function combinePositions(
         uint256 parentPositionId,


### PR DESCRIPTION
Allow staked vTokens to be withdrawn as NFTs if:
- Position has/had a timelock (this means that the position was created via NFTs, and isn't trying to avoid redeem fees)

User's staked vTokens are redeemed into NFTs and any residue vTokens are sent back to them.