### PR TITLE
fix: CreateVaultZap: Allow to pass large upperNFTPrice without overflow

### DIFF
--- a/src/lib/TickHelpers.sol
+++ b/src/lib/TickHelpers.sol
@@ -14,8 +14,13 @@ library TickHelpers {
         // sqrtP = sqrt(price) * 2^96
         // = sqrt(amount1 / amount0) * 2^96
         // = sqrt(amount1 * 2^192 / amount0)
+        // this restricts the max(amount1) to be (2^256 - 1)/(2^192) ~= 18.44e18
+        // so rearranging the formula, keeping sufficient precision
+        // = sqrt(amount1 * 2^142 / amount0) * 2^25
 
-        sqrtP = SafeCast.toUint160(Babylonian.sqrt((amount1 << 192) / amount0));
+        sqrtP = SafeCast.toUint160(
+            Babylonian.sqrt((amount1 * (2 ** 142)) / amount0) * (1 << 25)
+        );
     }
 
     function getTickForAmounts(

--- a/test/zaps/CreateVaultZap.t.sol
+++ b/test/zaps/CreateVaultZap.t.sol
@@ -100,11 +100,7 @@ contract CreateVaultZapTests is TestBase {
                 }),
                 liquidityParams: CreateVaultZap.LiquidityParams({
                     lowerNFTPriceInETH: 1,
-                    upperNFTPriceInETH: FullMath.mulDiv(
-                        TickMath.MAX_SQRT_RATIO,
-                        TickMath.MAX_SQRT_RATIO,
-                        2 << 192
-                    ) * 1 ether,
+                    upperNFTPriceInETH: (type(uint256).max / (1 << 142)),
                     fee: DEFAULT_FEE_TIER,
                     currentNFTPriceInETH: 4 ether,
                     vTokenMin: 0,
@@ -128,12 +124,12 @@ contract CreateVaultZapTests is TestBase {
         uint256 tickDistance = 200;
 
         // Max possible value without overflow
-        uint256 upperNFTPriceInETH = (type(uint256).max / (1 << 192)); // 18446744073709551615 or 18.446744073709551615 ETH
+        uint256 upperNFTPriceInETH = (type(uint256).max / (1 << 142));
         console.log("upperNFTPriceInETH", upperNFTPriceInETH);
 
         uint256 sqrtP = Babylonian.sqrt(
-            (upperNFTPriceInETH * (2 ** 192)) / 1 ether // replacing "<< 192" with "2 ** 192" to revert on overflow
-        );
+            (upperNFTPriceInETH * (2 ** 142)) / 1 ether // replacing "<<" with "2 **" to revert on overflow
+        ) * 2 ** 25;
         console.log("upperSqrtP", uint256(sqrtP));
 
         int24 tickUpper = TickHelpers.getTickForAmounts(
@@ -150,7 +146,11 @@ contract CreateVaultZapTests is TestBase {
         );
 
         uint256 lowerNFTPriceInETH = 1;
-        sqrtP = Babylonian.sqrt((lowerNFTPriceInETH << 192) / 1 ether);
+        sqrtP =
+            Babylonian.sqrt(
+                (upperNFTPriceInETH * (2 ** 142)) / 1 ether // replacing "<<" with "2 **" to revert on overflow
+            ) *
+            2 ** 25;
         console.log("lowerSqrtP", uint256(sqrtP));
         int24 tickLower = TickHelpers.getTickForAmounts(
             lowerNFTPriceInETH,


### PR DESCRIPTION
During calculation of the `sqrtP` in our CreateVaultZap, `upperNFTPrice * 2^192` resulted in an overflow bringing the sqrtP much lower than expected for higher values (like in the case of infinite range). The max possible `upperNFTPrice` was `18.44 ETH`.

So this fix modifies the calculation a bit to avoid overflows while maintaining sufficient precision and increases the max possible `upperNFTPrice` to `20769187434139310.51 ETH` (can be treated as infinite as far as the NFT prices go).