### PR TITLE
fix: NFPM: add unchecked blocks to allow underflow

### DIFF
--- a/src/uniswap/v3-periphery/NonfungiblePositionManager.sol
+++ b/src/uniswap/v3-periphery/NonfungiblePositionManager.sol
@@ -279,20 +279,25 @@ contract NonfungiblePositionManager is
 
         ) = pool.positions(positionKey);
 
-        position.tokensOwed0 += uint128(
-            FullMath.mulDiv(
-                feeGrowthInside0LastX128 - position.feeGrowthInside0LastX128,
-                position.liquidity,
-                FixedPoint128.Q128
-            )
-        );
-        position.tokensOwed1 += uint128(
-            FullMath.mulDiv(
-                feeGrowthInside1LastX128 - position.feeGrowthInside1LastX128,
-                position.liquidity,
-                FixedPoint128.Q128
-            )
-        );
+        // underflow expected here
+        unchecked {
+            position.tokensOwed0 += uint128(
+                FullMath.mulDiv(
+                    feeGrowthInside0LastX128 -
+                        position.feeGrowthInside0LastX128,
+                    position.liquidity,
+                    FixedPoint128.Q128
+                )
+            );
+            position.tokensOwed1 += uint128(
+                FullMath.mulDiv(
+                    feeGrowthInside1LastX128 -
+                        position.feeGrowthInside1LastX128,
+                    position.liquidity,
+                    FixedPoint128.Q128
+                )
+            );
+        }
 
         position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
         position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;
@@ -352,26 +357,29 @@ contract NonfungiblePositionManager is
 
         ) = pool.positions(positionKey);
 
-        position.tokensOwed0 +=
-            uint128(amount0) +
-            uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside0LastX128 -
-                        position.feeGrowthInside0LastX128,
-                    positionLiquidity,
-                    FixedPoint128.Q128
-                )
-            );
-        position.tokensOwed1 +=
-            uint128(amount1) +
-            uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside1LastX128 -
-                        position.feeGrowthInside1LastX128,
-                    positionLiquidity,
-                    FixedPoint128.Q128
-                )
-            );
+        // underflow expected here
+        unchecked {
+            position.tokensOwed0 +=
+                uint128(amount0) +
+                uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside0LastX128 -
+                            position.feeGrowthInside0LastX128,
+                        positionLiquidity,
+                        FixedPoint128.Q128
+                    )
+                );
+            position.tokensOwed1 +=
+                uint128(amount1) +
+                uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside1LastX128 -
+                            position.feeGrowthInside1LastX128,
+                        positionLiquidity,
+                        FixedPoint128.Q128
+                    )
+                );
+        }
 
         position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
         position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;
@@ -432,22 +440,25 @@ contract NonfungiblePositionManager is
                     )
                 );
 
-            tokensOwed0 += uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside0LastX128 -
-                        position.feeGrowthInside0LastX128,
-                    position.liquidity,
-                    FixedPoint128.Q128
-                )
-            );
-            tokensOwed1 += uint128(
-                FullMath.mulDiv(
-                    feeGrowthInside1LastX128 -
-                        position.feeGrowthInside1LastX128,
-                    position.liquidity,
-                    FixedPoint128.Q128
-                )
-            );
+            // underflow expected here
+            unchecked {
+                tokensOwed0 += uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside0LastX128 -
+                            position.feeGrowthInside0LastX128,
+                        position.liquidity,
+                        FixedPoint128.Q128
+                    )
+                );
+                tokensOwed1 += uint128(
+                    FullMath.mulDiv(
+                        feeGrowthInside1LastX128 -
+                            position.feeGrowthInside1LastX128,
+                        position.liquidity,
+                        FixedPoint128.Q128
+                    )
+                );
+            }
 
             position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
             position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;


### PR DESCRIPTION
Underflow/overflow is expected in feeGrowth calculations, but after upgrading the compiler version to solidity ^0.8, the in-built safemath prevents it unless `unchecked` is specified.

UniswapV3's solc 0.7.6 codebase, doesn't use safemath for the same calculations, for example: https://github.com/Uniswap/v3-periphery/blob/main/contracts/NonfungiblePositionManager.sol#L336