### PR TITLE
Changed IWETH9.sol to floating pragma and reinstalled forge-std

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
@@ -20,3 +17,6 @@
 [submodule "lib/permit2"]
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/src/uniswap/v3-periphery/interfaces/external/IWETH9.sol
+++ b/src/uniswap/v3-periphery/interfaces/external/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity ^0.8.15;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 


### PR DESCRIPTION
Downstream Foundry projects encounter integration issues in the form of a compiler error when importing INFTXVaultV3.sol. This is because it imports IWETH9.sol which has an outdated static pragma.

![image](https://github.com/NFTX-project/nftx-protocol-v3/assets/114717981/29d30af4-d3b8-4372-9207-77466357607d)

forge-std was also reinstalled as the submodule currently points towards a commit that no longer exists, preventing installation.

https://github.com/foundry-rs/forge-std/tree/8e0c3ee895277250627b5379c97b96f13bfb680c

![Screenshot 2024-03-26 130446](https://github.com/NFTX-project/nftx-protocol-v3/assets/114717981/40bdd4b0-2e85-4df2-a8cb-9f3d389d9294)
