### PR TITLE
Fix double-counting in getVTokenPremium1155.t.sol

### DIFF
--- a/test/unit/vault-factory/get-vtoken-premium-1155/getVTokenPremium1155.t.sol
+++ b/test/unit/vault-factory/get-vtoken-premium-1155/getVTokenPremium1155.t.sol
@@ -128,8 +128,6 @@ contract getVTokenPremium1155_Unit_Test is NFTXVaultFactory_Unit_Test {
         for (uint256 i; i < depositAmounts.length; i++) {
             depositAmounts[i] = bound(depositAmounts[i], 1, type(uint64).max);
 
-            totalDeposited += depositAmounts[i];
-
             nft1155.mint(tokenId, depositAmounts[i]);
 
             uint256[] memory tokenIds = new uint256[](1);


### PR DESCRIPTION
`forge test` output: 

Ran 41 test suites in 1.84s (12.02s CPU time): 285 tests passed, 0 failed, 0 skipped (285 total tests)

---

# Fix incorrect inventory tracking in fuzz test for `getVTokenPremium1155`

## Summary

This PR fixes a logic bug in the fuzz test
`test_WhenTheAmountIsLessThanOrEqualToTheQuantityOfNftsInTheVault`.

The test previously **double-counted deposited NFTs**, which caused incorrect assumptions about the vault's inventory and resulted in unexpected `NFTInventoryExceeded()` reverts during fuzzing.

This was a **test-side accounting error**, not a protocol vulnerability.

---

## Root Cause

Inside the deposit loop, the test incremented `totalDeposited` **twice**:

```solidity
totalDeposited += depositAmounts[i];          // first increment
...
vault.mint(...);
totalDeposited += depositAmounts[i];          // second increment
```

Since the vault only receives **one** deposit per iteration, the test inflated the perceived inventory to `2 × actual`.

As a result, fuzzing could pick values where:

* Real vault inventory = `N`
* Test’s `totalDeposited = 2N`
* Fuzzer chooses an amount `A` where `N < A ≤ 2N`

This made the test incorrectly expect success, while the contract correctly reverted.

---

## Fix

The double-counting has been removed. Now each deposit is counted exactly once:

```solidity
vault.mint({...});
totalDeposited += depositAmounts[i];
```

This aligns `totalDeposited` with the vault’s actual internal accounting.

---

## Impact

* Eliminates false positives from fuzzing.
* Ensures test assumptions match protocol behavior.
* Increases correctness and stability of the test suite.
* No production or contract-level changes.

---

## Testing

* Fuzz tests now pass consistently.
* No new failures introduced.
* Behavior now matches the expected premium logic for ERC1155 vaults.

---